### PR TITLE
preventing unnecessary influx call for non-exist failed points.

### DIFF
--- a/influxdb.go
+++ b/influxdb.go
@@ -127,6 +127,11 @@ func (cw clientWrapper) keepUpdated(ctx context.Context, ticker <-chan time.Time
 			Database:  cw.db,
 			Precision: "s",
 		})
+		
+		if len(pts) < 1 {
+			continue
+		}
+		
 		retryBatch.AddPoints(pts)
 
 		if err := cw.influxClient.Write(retryBatch); err != nil {

--- a/influxdb.go
+++ b/influxdb.go
@@ -122,15 +122,14 @@ func (cw clientWrapper) keepUpdated(ctx context.Context, ticker <-chan time.Time
 		for _, failedBP := range bpPending {
 			pts = append(pts, failedBP.Points()...)
 		}
+		if len(pts) < 1 {
+			continue
+		}
 
 		retryBatch, _ := client.NewBatchPoints(client.BatchPointsConfig{
 			Database:  cw.db,
 			Precision: "s",
 		})
-		
-		if len(pts) < 1 {
-			continue
-		}
 		
 		retryBatch.AddPoints(pts)
 


### PR DESCRIPTION
There is always an error log after successfully sending metrics to the influx.  I guess that's because this redundant influx call.

![image](https://user-images.githubusercontent.com/5918811/132712707-bd79458a-7921-4d80-9e78-8b2334609c55.png)
