### PR TITLE
KrakenD 2.1

### DIFF
--- a/influxdb.go
+++ b/influxdb.go
@@ -16,7 +16,7 @@ import (
 )
 
 const Namespace = "github_com/letgoapp/krakend-influx"
-const logPrefix = "[SERVICE: Influx]"
+const logPrefix = "[SERVICE: InfluxDB]"
 
 type clientWrapper struct {
 	influxClient client.Client


### PR DESCRIPTION
- Corrected the `logPrefix` to `SERVICE: InfluxDB` to make it match with the executor definitions and documentation.